### PR TITLE
Update main.py

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,11 +1,13 @@
 #!/usr/bin/python
 
 import json
+import ssl
 from typing import List
 import urllib.parse
 import random
 import http.client
 import sys
+import certifi
 import os
 
 
@@ -182,9 +184,9 @@ class Translate:
             "/singl" + \
             f"e?client=gtx&sl=auto&tl={self.lang}&dt=t&ie=UTF-8&oe=UTF-8&otf=1&ssel=0&tsel=0&kc=7&dt=at&dt=bd&dt=ex&dt=ld&dt=md&dt=qca&dt=rw&dt=rm&dt=ss&q={text_encoded}"
 
-    def _get_request(self, text):
+    def _get_request(self, text: str) -> dict:
         url, path = self._generate_url(text)
-        conn = http.client.HTTPSConnection(url)
+        conn = http.client.HTTPSConnection(url, context=ssl.create_default_context(cafile=certifi.where()))
         headers = {
             "User-Agent": self._get_user_agent(),
         }


### PR DESCRIPTION
### Solution for ssl certificate

I always use this workflow, but it stopped working a few days ago and this solved it. 

- Just have to add two imports in the `main.py` file of the Alfred workflow folder


```import ssl
import certifi
```

- and  changing these two lines:

```
def _get_request(self, text: str) -> dict:
```

```
conn = http.client.HTTPSConnection(url, context=ssl.create_default_context(cafile=certifi.where()))
```

